### PR TITLE
Fix styles not loading in the correct order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## v0.1.10
+
+- Justified library CSS - Add media-views stylesheet as a dependency.
+- Justified library CSS - Enqueued on the `wp_enqueue_media` action to ensure they are only loaded when required.
+
 ## v0.1.9
 
 - Fix bug when `full` isn't in sizes list, eg. everywhere except the HM site.

--- a/inc/justified-library/namespace.php
+++ b/inc/justified-library/namespace.php
@@ -12,5 +12,5 @@ function setup() {
 }
 
 function enqueue_scripts() {
-	wp_enqueue_style( 'hm-smart-media-justified-library', plugins_url( '/justified-library.css', __FILE__ ), [ 'media-views'], null );
+	wp_enqueue_style( 'hm-smart-media-justified-library', plugins_url( '/justified-library.css', __FILE__ ), [ 'media-views' ], null );
 }

--- a/inc/justified-library/namespace.php
+++ b/inc/justified-library/namespace.php
@@ -8,9 +8,9 @@
 namespace HM\Media\Justified_Gallery;
 
 function setup() {
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts', 20 );
+	add_action( 'wp_enqueue_media', __NAMESPACE__ . '\\enqueue_scripts', 20 );
 }
 
 function enqueue_scripts() {
-	wp_enqueue_style( 'hm-smart-media-justified-library', plugins_url( '/justified-library.css', __FILE__ ), [], null );
+	wp_enqueue_style( 'hm-smart-media-justified-library', plugins_url( '/justified-library.css', __FILE__ ), [ 'media-views'], null );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A smarter media library for WordPress",
   "scripts": {
     "build": "NODE_ENV=production webpack --config .config/webpack.config.js",

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.1.9
+ * Version: 0.1.10
  */
 
 namespace HM\Media;


### PR DESCRIPTION
We have a problem with the justified styles not working correctly when applied to a custom media upload button added to an edit term screen using CMB2.

The issue is that CMB2 calls `wp_enqueue_media` too late - after	`admin_enqueue_scripts`. 

I think the solution is 2 things.

1. The stylesheet `media-views` should be a dependency of `hm-smart-media-justified-library` to ensure the loading order is correct.
2. `hm-smart-media-justified-library` Should be enqueued on `wp_enqueue_media` action to ensure it is loaded only when actually needed.

