### PR TITLE
Apply smart-crop to post images

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -40,6 +40,7 @@ function setup() {
 
 	// Add crop data.
 	add_filter( 'tachyon_image_downsize_string', __NAMESPACE__ . '\\image_downsize', 10, 2 );
+	add_filter( 'tachyon_post_image_args', __NAMESPACE__ . '\\image_downsize', 10, 2 );
 }
 
 /**


### PR DESCRIPTION
Currently we only hook into `tachyon_image_downsize_string` which is a Tachyon hook that fires on `image_downsize` when using functions like `wp_get_attachment_image_src`. When Tachyon converts image URLs in the post content to Tachyon'ed images, no such function is called. We need to make use of the `tachyon_post_image_args` to filter those. The same args are passed to both filters, so it's a simple enough fix.