### PR TITLE
Fix warning fetching crop data

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -108,7 +108,7 @@ function image_downsize( $tachyon_args, $downsize_args ) {
  * Get crop data for a given image and size.
  *
  * @param int $attachment_id
- * @param string $size The image
+ * @param string $size
  * @return array|false
  */
 function get_crop( $attachment_id, $size ) {

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -188,11 +188,10 @@ function attachment_js( $response, $attachment ) {
 	$meta         = wp_get_attachment_metadata( $attachment->ID );
 	$backup_sizes = get_post_meta( $attachment->ID, '_wp_attachment_backup_sizes', true );
 
-	// Ensure width and height are set.
+	// Check width and height are set, in rare cases it can fail.
 	if ( ! isset( $meta['width'] ) || ! isset( $meta['height'] ) ) {
-		$dims = getimagesize( get_attached_file( $attachment->ID ) );
-		$meta['width'] = $dims[0] ?? 1;
-		$meta['height'] = $dims[1] ?? 1;
+		trigger_error( sprintf( 'Image metadata generation failed for image ID "%d", this may require manual resolution.', $attachment->ID ), E_USER_WARNING );
+		return $response;
 	}
 
 	$big   = max( $meta['width'], $meta['height'] );

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -112,8 +112,11 @@ function image_downsize( $tachyon_args, $downsize_args ) {
  * @return array|false
  */
 function get_crop( $attachment_id, $size ) {
-	// Check it's a size that can actually have crop data.
-	if ( in_array( $size, [ 'full', 'full-orig' ], true ) ) {
+	// Fetch all registered image sizes.
+	$sizes = get_image_sizes();
+
+	// Check it's that passed in size exists.
+	if ( ! isset( $sizes[ $size ] ) ) {
 		return false;
 	}
 
@@ -122,7 +125,7 @@ function get_crop( $attachment_id, $size ) {
 	// Infer crop from focal point if available.
 	if ( empty( $crop ) ) {
 		$meta_data = wp_get_attachment_metadata( $attachment_id );
-		$size      = get_image_sizes()[ $size ];
+		$size      = $sizes[ $size ];
 
 		$focal_point = get_post_meta( $attachment_id, '_focal_point', true ) ?: [];
 		$focal_point = array_map( 'absint', $focal_point );


### PR DESCRIPTION
Fixes #5

When retrieving crop data it was possible the passed in a size that didn't exist in the array returned from `get_image_sizes()`. This occurred any time `image_downsize` was called.

Also patches warnings when the image metadata failed to determine the original image width and size. Rare but seen on some sites we host, possibly related to image size.