### PR TITLE
Use Tachyon images everywhere

### DIFF
--- a/.config/webpack.config.js
+++ b/.config/webpack.config.js
@@ -61,6 +61,7 @@ const commonConfig = {
 		'@wordpress/media': { this: [ 'wp', 'media' ] },
 		'@wordpress/ajax': { this: [ 'wp', 'ajax' ] },
 		'@wordpress/template': { this: [ 'wp', 'template' ] },
+		'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
 		'jQuery': 'jQuery',
 		lodash: '_',
 		wp: 'wp',

--- a/inc/cropper/media-template.php
+++ b/inc/cropper/media-template.php
@@ -231,6 +231,8 @@
 			<button type="button" class="button imgedit-undo button-reset" disabled><span class="screen-reader-text"><?php esc_html_e( 'Reset', 'hm-smart-media' ); ?></span></button>
 			<# if ( data.model.get( 'size' ) && data.model.get( 'sizes' )[ data.model.get( 'size' ) ].hasOwnProperty( 'cropData' ) && ! data.model.get( 'sizes' )[ data.model.get( 'size' ) ].cropData.hasOwnProperty( 'x' ) ) { #>
 				<p class="note-auto-crop"><?php esc_html_e( 'The crop was set automatically, to override it click and drag on the image then use the crop button.', 'hm-smart-media' ); ?></p>
+			<# } else { #>
+				<button type="button" class="button button-secondary button-remove-crop"><?php esc_html_e( 'Remove custom crop', 'hm-smart-media' ); ?></button>
 			<# } #>
 		</div>
 	<# } #>

--- a/inc/cropper/media-template.php
+++ b/inc/cropper/media-template.php
@@ -164,7 +164,7 @@
 					<?php esc_html_e( 'Original' ); ?>
 					<small>{{ data.model.get( 'width' ) }} x {{ data.model.get( 'height' ) }}</small>
 				</h3>
-				<img src="{{ data.model.get( 'tachyon_url' ) }}?fit=0,120" width="{{ data.model.get( 'width' ) }}" height="{{ data.model.get( 'height' ) }}" alt="original" draggable="false" />
+				<img src="{{ data.model.get( 'url' ) }}?fit=0,120" width="{{ data.model.get( 'width' ) }}" height="{{ data.model.get( 'height' ) }}" alt="original" draggable="false" />
 			</button>
 		</li>
 		<# if ( data.model.get( 'mime' ).match( /image\/(jpe?g|png|gif)/ ) ) { #>

--- a/inc/cropper/media-template.php
+++ b/inc/cropper/media-template.php
@@ -164,7 +164,7 @@
 					<?php esc_html_e( 'Original' ); ?>
 					<small>{{ data.model.get( 'width' ) }} x {{ data.model.get( 'height' ) }}</small>
 				</h3>
-				<img src="{{ data.model.get( 'url' ) }}?fit=0,120" width="{{ data.model.get( 'width' ) }}" height="{{ data.model.get( 'height' ) }}" alt="original" draggable="false" />
+				<img src="{{ data.model.get( 'tachyon_url' ) }}?fit=0,120" width="{{ data.model.get( 'width' ) }}" height="{{ data.model.get( 'height' ) }}" alt="original" draggable="false" />
 			</button>
 		</li>
 		<# if ( data.model.get( 'mime' ).match( /image\/(jpe?g|png|gif)/ ) ) { #>
@@ -230,7 +230,7 @@
 			<button type="button" class="button imgedit-crop button-apply-changes" disabled><span class="screen-reader-text"><?php esc_html_e( 'Apply changes', 'hm-smart-media' ); ?></span></button>
 			<button type="button" class="button imgedit-undo button-reset" disabled><span class="screen-reader-text"><?php esc_html_e( 'Reset', 'hm-smart-media' ); ?></span></button>
 			<# if ( data.model.get( 'size' ) && data.model.get( 'sizes' )[ data.model.get( 'size' ) ].hasOwnProperty( 'cropData' ) && ! data.model.get( 'sizes' )[ data.model.get( 'size' ) ].cropData.hasOwnProperty( 'x' ) ) { #>
-				<p class="note-auto-crop"><?php esc_html_e( 'The crop was set automatically, to override it click and drag on the image then use the crop button.' ); ?></p>
+				<p class="note-auto-crop"><?php esc_html_e( 'The crop was set automatically, to override it click and drag on the image then use the crop button.', 'hm-smart-media' ); ?></p>
 			<# } #>
 		</div>
 	<# } #>

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -921,15 +921,21 @@ function image_srcset( array $sources, array $size_array, string $image_src, arr
 	// Replace sources array.
 	$sources = [];
 
+	// Resize method.
+	$method = 'resize';
+	preg_match( '/(fit|resize|lb)=/', $image_src, $matches );
+	if ( isset( $matches[1] ) ) {
+		$method = $matches[1];
+	}
+
 	foreach ( $modifiers as $modifier ) {
 		$target_width = round( $width * $modifier );
 
 		// Apply zoom to the image to get automatic quality adjustment.
 		$zoomed_image_url = add_query_arg( [
-			'fit' => false,
 			'w' => false,
 			'h' => false,
-			'resize' => "{$width},{$height}",
+			$method => "{$width},{$height}",
 			'zoom' => $modifier,
 		], $image_src );
 

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -46,8 +46,10 @@ function setup() {
 		remove_filter( 'rest_request_before_callbacks', [ Tachyon::instance(), 'should_rest_image_downsize' ], 10, 3 );
 	}
 
-	// Ignore $content_width for display context.
-	add_filter( 'editor_max_image_size', __NAMESPACE__ . '\\editor_max_image_size', 10, 3 );
+	// Ignore $content_width in REST API responses.
+	add_action( 'rest_api_init', function () {
+		add_filter( 'editor_max_image_size', __NAMESPACE__ . '\\editor_max_image_size', 10, 2 );
+	} );
 
 	// Disable intermediate thumbnail file generation.
 	add_filter( 'intermediate_image_sizes_advanced', __NAMESPACE__ . '\\prevent_thumbnail_generation' );
@@ -987,14 +989,9 @@ function nearest_defined_crop_size( $ratio ) {
  *
  * @param array $size_array
  * @param string $size
- * @param string $context
  * @return array
  */
-function editor_max_image_size( array $size_array, string $size, string $context ) : array {
-	if ( $context !== 'display' ) {
-		return $size_array;
-	}
-
+function editor_max_image_size( array $size_array, string $size ) : array {
 	$sizes = get_image_sizes();
 
 	if ( ! isset( $sizes[ $size ] ) ) {

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -527,7 +527,7 @@ function filter_attachment_meta_data( $data, $attachment_id ) {
 	// Save time, only calculate once.
 	static $cache = [];
 
-	if ( isset( $cache[ $attachment_id ] ) ) {
+	if ( empty( $cache[ $attachment_id ] ) ) {
 		return $cache[ $attachment_id ];
 	}
 
@@ -594,6 +594,7 @@ function filter_attachment_meta_data( $data, $attachment_id ) {
 
 		// Add meta data with fake WP style file name.
 		$data['sizes'][ $size ] = [
+			'_tachyon_dynamic' => true,
 			'width' => $w,
 			'height' => $h,
 			'file' => "{$filename}{$crop_hash}-{$w}x{$h}.{$ext}",
@@ -644,6 +645,7 @@ function massage_meta_data_for_orientation( array $meta_data ) {
 	$width = $meta_data['height'];
 	$meta_data['height'] = $meta_data['width'];
 	$meta_data['width'] = $width;
+	unset( $meta_data['image_meta']['orientation'] );
 	return $meta_data;
 }
 

--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import Media from '@wordpress/media';
 import template from '@wordpress/template';
 import ImageEditView from './views/image-edit';
@@ -85,7 +86,7 @@ Media.events.on( 'frame:select:init', frame => {
   // Create new editing state.
   const editState = frame.states.add( {
     id: 'edit',
-    title: 'Edit image',
+    title: __( 'Edit image', 'hm-smart-media' ),
     router: false,
     menu: false,
     uploader: false,
@@ -129,7 +130,7 @@ Media.events.on( 'frame:select:init', frame => {
       event: 'select',
       items: {
         change: {
-          text: 'Change image',
+          text: __( 'Change image', 'hm-smart-media' ),
           click() {
             frame.setState( frame.lastState() );
           },
@@ -138,7 +139,7 @@ Media.events.on( 'frame:select:init', frame => {
         },
         apply: {
           style: 'primary',
-          text: 'Select',
+          text: __( 'Select', 'hm-smart-media' ),
           click: () => {
             const { close, event, reset, state } = frame.options.mutableButton || frame.options.button || {};
 

--- a/inc/cropper/src/views/image-editor.js
+++ b/inc/cropper/src/views/image-editor.js
@@ -17,6 +17,7 @@ const ImageEditor = Media.View.extend( {
 	events: {
 		'click .button-apply-changes': 'saveCrop',
 		'click .button-reset': 'reset',
+		'click .button-remove-crop': 'removeCrop',
 		'click .image-preview-full': 'onClickPreview',
 		'click .focal-point': 'removeFocalPoint',
 		'click .imgedit-menu button': 'onEditImage',
@@ -250,6 +251,18 @@ const ImageEditor = Media.View.extend( {
 		this.$el.find( '.focal-point' ).hide();
 		event.stopPropagation();
 		this.setFocalPoint( false );
+	},
+	removeCrop() {
+		ajax.post( 'hm_remove_crop', {
+			_ajax_nonce: this.model.get( 'nonces' ).edit,
+			id: this.model.get( 'id' ),
+			size: this.model.get( 'size' ),
+		} )
+			.done( () => {
+				// Update & re-render.
+				this.update();
+			} )
+			.fail( error => console.log( error ) );
 	},
 	onEditImage() {
 		this.$el.find( '.focal-point, .note-focal-point' ).hide();

--- a/inc/cropper/src/views/image-editor.js
+++ b/inc/cropper/src/views/image-editor.js
@@ -54,9 +54,12 @@ const ImageEditor = Media.View.extend( {
 		this.update();
 	},
 	update() {
-		wp && wp.data && wp.data.dispatch( 'core' ).saveMedia( {
-			id: this.model.get( 'id' ),
-		} );
+		// Update the redux store in gutenberg.
+		if ( wp && wp.data ) {
+			wp.data.dispatch( 'core' ).saveMedia( {
+				id: this.model.get( 'id' ),
+			} );
+		}
 		this.model.fetch( {
 			success: () => this.loadEditor(),
 			error: () => {},

--- a/inc/cropper/src/views/image-editor.js
+++ b/inc/cropper/src/views/image-editor.js
@@ -54,13 +54,19 @@ const ImageEditor = Media.View.extend( {
 		this.update();
 	},
 	update() {
+		wp && wp.data && wp.data.dispatch( 'core' ).saveMedia( {
+			id: this.model.get( 'id' ),
+		} );
 		this.model.fetch( {
 			success: () => this.loadEditor(),
 			error: () => {},
 		} );
 	},
+	applyRatio() {
+		const ratio = this.model.get( 'width' ) / Math.min( 1000, this.model.get( 'width' ) );
+		return [ ...arguments ].map( dim => Math.round( dim * ratio ) );
+	},
 	reset() {
-		const $image     = $( 'img[id^="image-preview-"]' );
 		const sizeName   = this.model.get( 'size' );
 		const sizes      = this.model.get( 'sizes' );
 		const focalPoint = this.model.get( 'focalPoint' );
@@ -86,8 +92,9 @@ const ImageEditor = Media.View.extend( {
 					height: cropHeight,
 				} );
 			} else {
+				const image = $( 'img[id^="image-preview-"]' ).get( 0 );
 				smartcrop
-					.crop( $image.get( 0 ), {
+					.crop( image, {
 						width: size.width,
 						height: size.height,
 					} )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.1.13",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3276,8 +3276,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3298,14 +3297,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3320,20 +3317,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3450,8 +3444,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3463,7 +3456,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3478,7 +3470,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3486,14 +3477,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3512,7 +3501,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3593,8 +3581,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3606,7 +3593,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3692,8 +3678,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3729,7 +3714,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3749,7 +3733,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3793,14 +3776,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
This PR brings in the work @peterwilsoncc did on his own site to get Tachyon working across the board, especially the block editor.

This will need some thorough testing particular in terms of backwards compatibility but it fixes the problem of cropping choices and smart cropping not being reflected in the editor which is confusing for users.