### PR TITLE
Handle max size when non-named crop size is requested

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -994,7 +994,7 @@ function nearest_defined_crop_size( $ratio ) {
  * Ignore the $content_width global in the display context.
  *
  * @param array $size_array
- * @param string $size
+ * @param string|array $size
  * @return array
  */
 function editor_max_image_size( array $size_array, $size ) : array {

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -997,7 +997,12 @@ function nearest_defined_crop_size( $ratio ) {
  * @param string $size
  * @return array
  */
-function editor_max_image_size( array $size_array, string $size ) : array {
+function editor_max_image_size( array $size_array, $size ) : array {
+
+	if ( is_array( $size ) ) {
+		return $size;
+	}
+
 	$sizes = get_image_sizes();
 
 	if ( ! isset( $sizes[ $size ] ) ) {


### PR DESCRIPTION
If an image crop size is requested for a non-named image size, uses that size as a "editor max width" dimensions. Prevents fatals in the block editor when plugins which define image sizes as an array are present - for example, Gaussholder lo-res intermediate sizes.

Fixes #21.