### PR TITLE
Only hide the image link in smart media edit mode

### DIFF
--- a/inc/cropper/src/cropper.scss
+++ b/inc/cropper/src/cropper.scss
@@ -1,8 +1,11 @@
 /* Hide built in image editor */
 .wp-core-ui {
-	.edit-attachment,
-	.button[id^="imgedit-open-btn-"] {
-		display: none;
+
+	&.mode-edit-image {
+		.edit-attachment,
+		.button[id^="imgedit-open-btn-"] {
+			display: none;
+		}
 	}
 
 	.media-image-edit {


### PR DESCRIPTION
Currently the featured image edit mode integration only works if you have the block editor enabled. This change ensures that the old image edit link still shows in that scenario to avoid a UX regression.