### PR TITLE
Check return value of image meta data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.2.4
+
+- Bug: Check metadata is an array before passing to `add_srcset_and_sizes()`
+
 ## v0.2.3
 
 - Bug: Don't hide edit image link if smart media UI not active #30

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -774,7 +774,11 @@ function make_content_images_responsive( string $content ) : string {
 	foreach ( $selected_images as $image => $image_data ) {
 		$attachment_id = $image_data['id'];
 		$image_meta = wp_get_attachment_metadata( $attachment_id );
-		$content = str_replace( $image, add_srcset_and_sizes( $image_data, $image_meta, $attachment_id ), $content );
+		if ( $image_meta ) {
+			$content = str_replace( $image, add_srcset_and_sizes( $image_data, $image_meta, $attachment_id ), $content );
+		} else {
+			trigger_error( sprintf( 'Could not retrieve image meta data for Attachment ID "%s"', (string) $attachment_id ), E_USER_WARNING );
+		}
 	}
 
 	return $content;

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -178,6 +178,10 @@ function get_crop( int $attachment_id, string $size ) : ?array {
 	// Infer crop from focal point if available.
 	if ( empty( $crop ) ) {
 		$meta_data = wp_get_attachment_metadata( $attachment_id );
+		if ( ! $meta_data ) {
+			return null;
+		}
+
 		$size      = $sizes[ $size ];
 
 		$focal_point = get_post_meta( $attachment_id, '_focal_point', true ) ?: [];
@@ -242,7 +246,12 @@ function attachment_js( $response, $attachment ) {
 		return $response;
 	}
 
-	$meta         = wp_get_attachment_metadata( $attachment->ID );
+	$meta = wp_get_attachment_metadata( $attachment->ID );
+
+	if ( ! $meta ) {
+		return $response;
+	}
+
 	$backup_sizes = get_post_meta( $attachment->ID, '_wp_attachment_backup_sizes', true );
 
 	// Check width and height are set, in rare cases it can fail.

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -774,7 +774,7 @@ function make_content_images_responsive( string $content ) : string {
 	foreach ( $selected_images as $image => $image_data ) {
 		$attachment_id = $image_data['id'];
 		$image_meta = wp_get_attachment_metadata( $attachment_id );
-		if ( $image_meta ) {
+		if ( $image_meta && is_array( $image_meta ) ) {
 			$content = str_replace( $image, add_srcset_and_sizes( $image_data, $image_meta, $attachment_id ), $content );
 		} else {
 			trigger_error( sprintf( 'Could not retrieve image meta data for Attachment ID "%s"', (string) $attachment_id ), E_USER_WARNING );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.2.3
+ * Version: 0.2.4
  */
 
 namespace HM\Media;


### PR DESCRIPTION
If the attachment post can't be found then `wp_get_attachment_metadata()` returns false. This wasn't being checked before passing to `add_srcset_and_sizes()` which has a type hint for that value.