### PR TITLE
Remove the new default core image sizes

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -75,6 +75,10 @@ function setup() {
 
 	// Calculate srcset based on zoom modifiers.
 	add_filter( 'wp_calculate_image_srcset', __NAMESPACE__ . '\\image_srcset', 10, 5 );
+
+	// Remove the core additional sizes 1536x1536 and 2048x2048 as we use Tachyon's zoom.
+	remove_image_size( '1536x1536' );
+	remove_image_size( '2048x2048' );
 }
 
 /**


### PR DESCRIPTION
Core now adds image sizes 1536x1536 and 2048x2048. As we're using Tachyon and the `zoom` parameter for srcset this just adds clutter and more things to crop.