### PR TITLE
Double check attachment ID is int

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -148,6 +148,7 @@ function image_downsize( array $tachyon_args, array $downsize_args ) : array {
 		return $tachyon_args;
 	}
 	
+	// The value we're picking up can be filtered and upstream bugs introduced, this will avoid fatal errors.
 	if ( ! is_int( $downsize_args['attachment_id'] ) ) {
 		return $tachyon_args;
 	}

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -147,6 +147,10 @@ function image_downsize( array $tachyon_args, array $downsize_args ) : array {
 	if ( ! isset( $downsize_args['attachment_id'] ) || ! isset( $downsize_args['size'] ) ) {
 		return $tachyon_args;
 	}
+	
+	if ( ! is_int( $downsize_args['attachment_id'] ) ) {
+		return $tachyon_args;
+	}
 
 	$crop = get_crop( $downsize_args['attachment_id'], $downsize_args['size'] );
 


### PR DESCRIPTION
The value we're picking up can be filtered and upstream bugs introduced, this will avoid unnecessary fatals.