### PR TITLE
Fix media Details fatal error

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -124,7 +124,7 @@ function rest_api_fields( WP_REST_Response $response ) : WP_REST_Response {
 	}
 
 	// Confirm it's definitely an image.
-	if ( ! isset( $data['id'] ) || ! isset( $data['media_type'] ) || ! is_array( $data['media_details'] ) ) {
+	if ( ! isset( $data['id'] ) || ! isset( $data['media_type'] ) ) {
 		return $response;
 	}
 
@@ -141,7 +141,7 @@ function rest_api_fields( WP_REST_Response $response ) : WP_REST_Response {
 		}
 	}
 
-	if ( isset( $data['media_details']['sizes'] ) ) {
+	if ( is_array( $data['media_details'] ) && isset( $data['media_details']['sizes'] ) ) {
 		$full_size_thumb = $data['media_details']['sizes']['full']['source_url'];
 		foreach ( $data['media_details']['sizes'] as $name => $size ) {
 			// Remove internal flag.

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -141,7 +141,7 @@ function rest_api_fields( WP_REST_Response $response ) : WP_REST_Response {
 		}
 	}
 
-	if ( is_array( $data['media_details'] ) && isset( $data['media_details']['sizes'] ) ) {
+	if ( isset( $data['media_details'] ) && is_array( $data['media_details'] ) && isset( $data['media_details']['sizes'] ) ) {
 		$full_size_thumb = $data['media_details']['sizes']['full']['source_url'];
 		foreach ( $data['media_details']['sizes'] as $name => $size ) {
 			// Remove internal flag.

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -124,7 +124,7 @@ function rest_api_fields( WP_REST_Response $response ) : WP_REST_Response {
 	}
 
 	// Confirm it's definitely an image.
-	if ( ! isset( $data['id'] ) || ! isset( $data['media_type'] ) ) {
+	if ( ! isset( $data['id'] ) || ! isset( $data['media_type'] ) || ! is_array( $data['media_details'] ) ) {
 		return $response;
 	}
 
@@ -162,7 +162,7 @@ function rest_api_fields( WP_REST_Response $response ) : WP_REST_Response {
 			if ( $data['media_type'] === 'image' ) {
 				// Add crop data.
 				if ( $name !== 'full' ) {
-					$size['crop'] = get_crop( $data['id'], $size );
+					$size['crop'] = get_crop( $data['id'], $name );
 				}
 				// Correct full size image details.
 				if ( $name === 'full' ) {


### PR DESCRIPTION
Under certain circumstances, an attachment may not have sizes properly generated. For instance, when the attachment has been cloned by another plugin. This case is leading to a fatal error because `$data['media_details']` is not an array but an object.

There was another error because this line `get_crop( $data['id'], $size );` was passing the list of sizes as an array but `get_crop()` is expecting the size name instead so I changed it to `get_crop( $data['id'], $name );` and looks good.