### PR TITLE
Fix: Image Size Selector not working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.2.8
+
+- Bug: Fix image size selector in Image Block wasn't selecting the correct size and switching between sizes wasn't causing any resize in the block.
+ 
 ## v0.2.7
 
 - Bug: Fix error when `media_details` is empty in REST response

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -338,6 +338,18 @@ function attachment_js( $response, $attachment ) {
 	// Fill intermediate sizes array.
 	$sizes = get_image_sizes();
 
+	if ( isset( $response['sizes']['full'] ) ) {
+		$full_size_attrs = $response['sizes']['full'];
+
+		// Fill the full size manually as the Media Library needs this size.
+		$sizes['full'] = [
+			'width'       => $full_size_attrs['width'],
+			'height'      => $full_size_attrs['height'],
+			'crop'        => false,
+			'orientation' => $full_size_attrs['width'] >= $full_size_attrs['height'] ? 'landscape' : 'portrait'
+		];
+	}
+
 	$size_labels = apply_filters( 'image_size_names_choose', [
 		'thumbnail' => __( 'Thumbnail' ),
 		'medium'    => __( 'Medium' ),

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -142,8 +142,8 @@ function rest_api_fields( WP_REST_Response $response ) : WP_REST_Response {
 	}
 
 	if ( isset( $data['media_details'] ) && is_array( $data['media_details'] ) && isset( $data['media_details']['sizes'] ) ) {
-		$full_size_thumb = $data['media_details']['sizes']['full']['source_url'];
-		foreach ( $data['media_details']['sizes'] as $name => $size ) {
+		$full_size_thumb = $data['original_url'] ?? $data['media_details']['sizes']['full']['source_url'];
+ 		foreach ( $data['media_details']['sizes'] as $name => $size ) {
 			// Remove internal flag.
 			unset( $size['_tachyon_dynamic'] );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.2.7
+ * Version: 0.2.8
  */
 
 namespace HM\Media;


### PR DESCRIPTION
## How to reproduce

1. Open the JS console
2. Insert an image block
3. Select an image with `original` size
4. See the console error

![Captura de pantalla 2020-03-23 a las 15 11 18](https://user-images.githubusercontent.com/1516569/77329568-70f87900-6d1e-11ea-97d2-2bb98f6ccfb7.png)

5. Now try to change the image size. Depending on what size you select, the change won't happen.

## What's the problem

This is because the `full` image size is not returned in `wp_prepare_attachment_for_js()`. This would be the standard behaviour but these lines were **preventing the `full` size to be sent in the response when the Media Library was fetching images**: https://github.com/humanmade/smart-media/blob/master/inc/cropper/namespace.php#L339-L361

Once an image was selected, these lines were in charge of getting the image data: https://github.com/humanmade/smart-media/blob/master/inc/cropper/src/cropper.js#L205-L209

Unfortunately, if the full image was selected, `const image = sizes[ size ];`,  `image` turned to be `undefined`, throwing a console error and the Image Size Selector in the Image Block wasn't catching the proper value.

The second problem was that when an image block is selected in Gutenberg, this will fetch for the image data. **There were differences between what was got from the Media Library and what was got from the REST API because the tachyon URLs were different**. The line here https://github.com/humanmade/smart-media/blob/master/inc/cropper/namespace.php#L155 was not returning a proper Tachyon URL because `$full_size_thumb` was already a Tachyon URL (only for the full size), `tachyon_url()` function was returning the same image URL without resizing arguments. Passing the `original_url` solved the issue.