### PR TITLE
Prevent srcset requesting images larger than the original

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## v0.2.10
+
+- Bug: Ensure `srcset` sizes are never larger than the original
+- Bug: Ensure originally requested size (or as close to) is represented in `srcset`
+
 ## v0.2.9
 
 - Bug: Fix crop position in post featured images #52

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.2.9
+ * Version: 0.2.10
  */
 
 namespace HM\Media;


### PR DESCRIPTION
In Tachyon we removed the ability to upscale images beyond the original dimensions, as a result the zoom modifiers could request a larger image than the original but not receive the expected size back from Tachyon.

Because the `srcset` modifier didnt account for this the browser would incorrectly render the image at a smaller size than intended because it assumed it was dealing with a larger image. This resulted in a shrinking effect when rendered in the browser.

This ensures that `srcset` URLs are never larger than the original image.

Additionally it seems in some browsers if there any `srcset` URLs available it will never fall back to the original `img` tag URL but instead use the closest `srcset` URL it can find, because of this we also force a `srcset` size with `zoom=1` to ensure the original size is available as well.