### PR TITLE
Don't apply Tachyon URLs to SVGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.2.11
+
+- Bug: Tachyon no longer processes SVGs, they stopped displaying properly in the media modal as a result
+
 ## v0.2.10
 
 - Bug: Ensure `srcset` sizes are never larger than the original

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -333,7 +333,7 @@ function attachment_js( $response, $attachment ) {
 	}
 
 	// Add base Tachyon URL.
-	if ( function_exists( 'tachyon_url' ) && Tachyon::validate_image_url( $response['url'] ) ) {
+	if ( method_exists( 'Tachyon', 'validate_image_url' ) && Tachyon::validate_image_url( $response['url'] ) ) {
 		$response['original_url'] = $response['url'];
 		$response['url'] = tachyon_url( $response['url'] );
 	}

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -389,7 +389,7 @@ function attachment_js( $response, $attachment ) {
  * @return array
  */
 function attachment_thumbs( $response ) : array {
-	if ( ! function_exists( 'tachyon_url' ) || ! is_array( $response ) || ! Tachyon::validate_image_url( $response['url'] ) ) {
+	if ( ! method_exists( 'Tachyon', 'validate_image_url' ) || ! is_array( $response ) || ! Tachyon::validate_image_url( $response['url'] ) ) {
 		return $response;
 	}
 

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -333,7 +333,7 @@ function attachment_js( $response, $attachment ) {
 	}
 
 	// Add base Tachyon URL.
-	if ( function_exists( 'tachyon_url' ) ) {
+	if ( function_exists( 'tachyon_url' ) && Tachyon::validate_image_url( $response['url'] ) ) {
 		$response['original_url'] = $response['url'];
 		$response['url'] = tachyon_url( $response['url'] );
 	}
@@ -389,7 +389,7 @@ function attachment_js( $response, $attachment ) {
  * @return array
  */
 function attachment_thumbs( $response ) : array {
-	if ( ! function_exists( 'tachyon_url' ) || ! is_array( $response ) ) {
+	if ( ! function_exists( 'tachyon_url' ) || ! is_array( $response ) || ! Tachyon::validate_image_url( $response['url'] ) ) {
 		return $response;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.7",
+  "version": "0.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.2.10
+ * Version: 0.2.11
  */
 
 namespace HM\Media;


### PR DESCRIPTION
Currently SVGs are treated the same as all other image types in Smart Media, but that isn't quite true, as SVGs should not be passed to Tachyon, or croppable etc. This makes use of Tachyon::validate_image_url to only apply the treatment when necessary.

Fixes #57 