### PR TITLE
Fix SVG display in the media modal popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.2.12
+
+- Bug: Fix SVG preview display in media modal
+
 ## v0.2.11
 
 - Bug: Tachyon no longer processes SVGs, they stopped displaying properly in the media modal as a result

--- a/inc/cropper/media-template.php
+++ b/inc/cropper/media-template.php
@@ -272,7 +272,7 @@
 
 <script type="text/html" id="tmpl-hm-thumbnail-preview">
 	<div class="hm-thumbnail-editor__image-wrap">
-		<div class="hm-thumbnail-editor__image">
+		<div class="hm-thumbnail-editor__image hm-thumbnail-editor__image--preview">
 			<# if ( data.model.get( 'sizes' ) ) { #>
 				<img
 					class="image-preview"

--- a/inc/cropper/src/cropper.scss
+++ b/inc/cropper/src/cropper.scss
@@ -112,6 +112,9 @@
 				margin-bottom: 0;
 				font-size: 16px;
 			}
+			button::before {
+				margin-left: 8px;
+			}
 		}
 
 		&__image-wrap {
@@ -126,12 +129,20 @@
 				position: relative;
 			}
 
+			&--preview {
+				float: none;
+			}
+
 			img {
 				display: block;
 				max-width: 100%;
 				max-height: 500px;
 				width: auto;
 				height: auto;
+			}
+
+			img[src$=".svg"] {
+				width: 100%;
 			}
 
 			.image-preview-full {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.2.11
+ * Version: 0.2.12
  */
 
 namespace HM\Media;


### PR DESCRIPTION
Depending on the SVG markup itself some SVGs would be displayed at 0x0 pixels. This ensures that when the media modal is in preview mode eg. not edit mode that the image is displayed at an appropriate size, SVGs are now displayed as large as possible.

Fixes #58 