### PR TITLE
Check the current frame state has the select event before firing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## v0.2.13
+
+- Bug: Compatibility issue with Google AMP plugin
+- Bug: Selecting a featured image on an auto draft / new post page could fail to trigger the select event
+
 ## v0.2.12
 
 - Bug: Fix SVG preview display in media modal

--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -190,8 +190,16 @@ Media.events.on( 'frame:select:init', frame => {
               frame.close();
             }
 
+            // Trigger the event on the current state if available, falling
+            // back to last state and finally the frame.
             if ( event ) {
-              frame.state().trigger( event || 'select' );
+              if ( frame.state()._events[ event ] ) {
+                frame.state().trigger( event );
+              } else if ( frame.lastState()._events[ event ] ) {
+                frame.lastState().trigger( event );
+              } else {
+                frame.trigger( event );
+              }
             }
 
             if ( state ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.2.12
+ * Version: 0.2.13
  */
 
 namespace HM\Media;


### PR DESCRIPTION
In some instances the edit image frame state does not inherit the `select` event from the previous state. This update will check that first, falling back to the select event on the last state and finally the frame itself.

This was only really apparent when creating a brand new post and also could cause an error when used in conjucntion with the Google AMP plugin's own hooks into the media frame featured image state.

Fixes #60