### PR TITLE
Allow size attributes

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -43,6 +43,7 @@ function setup() {
 	 */
 	add_filter( 'tachyon_pre_args', __NAMESPACE__ . '\\tachyon_args' );
 	add_filter( 'tachyon_disable_in_admin', '__return_false' );
+	add_filter( 'tachyon_remove_size_attributes', '__return_false' );
 	if ( class_exists( 'Tachyon' ) ) {
 		remove_filter( 'rest_request_before_callbacks', [ Tachyon::instance(), 'should_rest_image_downsize' ], 10, 3 );
 	}


### PR DESCRIPTION
Tachyon by default will remove `width` and `height` attributes on images, because we're now maintaining the aspect ratio in the `srcset` attribute by using `zoom` we can safely leave these intact. It will help improve lazy loading support and reduce layout reflow during page loads.

Fixes #67