### PR TITLE
Check uploader status is rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 Changelog
 =========
 
-## v0.2.19
+## v0.2.20
 
 - Bug: Fix uploader error after inserting existing media into post
+
+## v0.2.19
+
 - Enhancement: Add width and height attributes to images in media library to improve loading and fix layout jitter
 
 ## v0.2.18

--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -147,9 +147,6 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
     libraryState.get( 'selection' ).on( 'selection:single', () => {
       const single = this.state( 'edit' ).get( 'selection' ).single();
       if ( single.get( 'uploading' ) ) {
-        // Manually trigger the ready event on the content subviews to ensure
-        // the uploader status view is properly set up.
-        this.content.trigger( 'ready' );
         return;
       }
 
@@ -367,4 +364,18 @@ Media.view.Attachment.EditLibrary = MediaAttachmentEditLibrary.extend( {
 } );
 Media.view.Attachment.Selection = MediaAttachmentSelection.extend( {
   render: overrideRender,
+} );
+
+/**
+ * Ensure uploader status view is actually rendered before
+ * updating info display.
+ */
+const MediaUploaderStatus = Media.view.UploaderStatus;
+Media.view.UploaderStatus = MediaUploaderStatus.extend( {
+  info: function () {
+    if ( ! this.$index ) {
+      return;
+    }
+    MediaUploaderStatus.prototype.info.apply( this, arguments );
+  }
 } );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.2.19
+ * Version: 0.2.20
  */
 
 namespace HM\Media;


### PR DESCRIPTION
When uploading a single item the media modal can switch view back to the library. The uploader status bar on the upload view is no longer rendered but the model is still updated causing it to try and update DOM nodes that don't exist leading to an error and preventing the upload from excuting successfully.