### PR TITLE
Check for existing query string in sizes list

### DIFF
--- a/inc/cropper/media-template.php
+++ b/inc/cropper/media-template.php
@@ -170,7 +170,7 @@
 					<?php esc_html_e( 'Original' ); ?>
 					<small>{{ data.model.get( 'width' ) }} x {{ data.model.get( 'height' ) }}</small>
 				</h3>
-				<img src="{{ data.model.get( 'url' ) }}?fit=0,120" width="{{ data.model.get( 'width' ) }}" height="{{ data.model.get( 'height' ) }}" alt="original" draggable="false" />
+				<img src="{{ data.model.get( 'url' ) + ( data.model.get( 'url' ).indexOf( '?' ) >= 0 ? '&amp;' : '?' ) }}fit=0,120" width="{{ data.model.get( 'width' ) }}" height="{{ data.model.get( 'height' ) }}" alt="original" draggable="false" />
 			</button>
 		</li>
 		<# if ( data.model.get( 'mime' ).match( /image\/(jpe?g|png|gif)/ ) ) { #>


### PR DESCRIPTION
In the some cases such as private uploads support the original image URL may already contain a query string. We should account for this in the template.

Fixes #93