### PR TITLE
Support uploading image in edit state

### DIFF
--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -151,9 +151,6 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
     // Handle selection events.
     libraryState.get( 'selection' ).on( 'selection:single', () => {
       const single = this.state( 'edit' ).get( 'selection' ).single();
-      if ( single.get( 'uploading' ) ) {
-        return;
-      }
 
       // Update the placeholder the featured image frame uses to set its
       // default selection from.

--- a/inc/cropper/src/views/image-edit-sizes.js
+++ b/inc/cropper/src/views/image-edit-sizes.js
@@ -13,8 +13,15 @@ const ImageEditSizes = Media.View.extend( {
 	},
 	initialize() {
 		this.listenTo( this.model, 'change:sizes', this.render );
+		this.listenTo( this.model, 'change:uploading', this.render );
+		if ( ! this.model.get( 'size' ) ) {
+			this.model.set( { size: 'full' } );
+		}
 		this.on( 'ready', () => {
-			this.el.querySelector( '.current' ).scrollIntoView();
+			const current = this.el.querySelector( '.current' );
+			if ( current ) {
+				current.scrollIntoView();
+			}
 		} );
 	},
 	setSize( e ) {

--- a/inc/cropper/src/views/image-edit.js
+++ b/inc/cropper/src/views/image-edit.js
@@ -57,7 +57,11 @@ const ImageEditView = Media.View.extend( {
 		const views = [];
 
 		// If the attachment info hasn't loaded yet show a spinner.
-		if ( this.model.get( 'uploading' ) || ( this.model.get( 'id' ) && ! this.model.get( 'url' ) ) ) {
+		if ( this.model.get( 'uploading' ) ) {
+			views.push( new Media.view.UploaderStatus( {
+				controller: this.controller,
+			} ) );
+		} else if ( this.model.get( 'id' ) && ! this.model.get( 'url' ) ) {
 			views.push( new Media.view.Spinner() );
 		} else {
 			// Ensure this attachment is editable.


### PR DESCRIPTION
Previously when uploading an image switching to the image editor state was blocked. This could be confusing as youd have to deselect and reselect the image to edit it, or just insert it into the post. This change shows the upload status in the editor window until the image is ready instead