### PR TITLE
Fix: TypeError in Classic Editor

### DIFF
--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -269,7 +269,7 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
 
             // Update current block if we can map the attachment to attributes.
             if ( wp && wp.data ) {
-              const selectedBlock = wp.data.select( 'core/block-editor' ).getSelectedBlock();
+              const selectedBlock = wp.data.select( 'core/block-editor' )?.getSelectedBlock();
               if ( ! selectedBlock ) {
                 return;
               }

--- a/inc/cropper/src/views/image-edit.js
+++ b/inc/cropper/src/views/image-edit.js
@@ -30,7 +30,7 @@ const ImageEditView = Media.View.extend( {
 			return;
 		}
 
-		const selectedBlock = wp.data.select( 'core/block-editor' ).getSelectedBlock();
+		const selectedBlock = wp.data.select( 'core/block-editor' )?.getSelectedBlock();
 		if ( ! selectedBlock ) {
 			return;
 		}

--- a/inc/cropper/src/views/image-editor.js
+++ b/inc/cropper/src/views/image-editor.js
@@ -61,7 +61,7 @@ const ImageEditor = Media.View.extend( {
 	},
 	update() {
 		// Update the redux store in gutenberg.
-		if ( wp && wp.data ) {
+		if ( wp && wp.data && wp.data.dispatch( 'core' )?.saveMedia ) {
 			wp.data.dispatch( 'core' ).saveMedia( {
 				id: this.model.get( 'id' ),
 			} );


### PR DESCRIPTION
In some cases (we've seen one with Classic Editor) `wp.data` can be loaded but `'core/block-editor'` store is returning undefined. In that case, the changed line was returning a TypeError that was preventing a featured image to be selected.

<img width="322" alt="screenshot_2020-10-09_at_09 26 29" src="https://user-images.githubusercontent.com/1516569/95564416-0b03e280-0a1f-11eb-9e07-88e7a422de66.png">
