### PR TITLE
Fix fake attachment handling

### DIFF
--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -152,6 +152,12 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
     libraryState.get( 'selection' ).on( 'selection:single', () => {
       const single = this.state( 'edit' ).get( 'selection' ).single();
 
+      // Check that the attachment is a complete object. Built in placeholders
+      // exist for the cover block that can confuse things.
+      if ( ! single.get( 'url' ) ) {
+        return;
+      }
+
       // Update the placeholder the featured image frame uses to set its
       // default selection from.
       if ( isFeaturedImage ) {


### PR DESCRIPTION
In some instances the block editor provides default images such as the cover block. These do not exist as real attachments but are represented by an attachment object containing just an ID property. This updates checks for additional attachment object data before proceeding to switch to the edit state.

Fixes #108