### PR TITLE
Do not load editor if editor property missing on attachment model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.3.9
+
+- Bug: Fall back to regular preview when missing `editor` object on attachment model
+
 ## v0.3.8
 
 - Bug: Ensure srcset URLs are properly escaped

--- a/inc/cropper/src/views/image-edit.js
+++ b/inc/cropper/src/views/image-edit.js
@@ -65,7 +65,7 @@ const ImageEditView = Media.View.extend( {
 			views.push( new Media.view.Spinner() );
 		} else {
 			// Ensure this attachment is editable.
-			if ( this.model.get( 'mime' ).match( /image\/(gif|jpe?g|png)/ ) ) {
+			if ( this.model.get( 'editor' ) && this.model.get( 'mime' ).match( /image\/(gif|jpe?g|png)/ ) ) {
 				views.push( new ImageEditSizes( {
 					controller: this.controller,
 					model: this.model,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.3.8
+ * Version: 0.3.9
  */
 
 namespace HM\Media;


### PR DESCRIPTION
This ensures that the media modal does not break when using AMF WP.

Fixes https://github.com/humanmade/altis-media/issues/101