### PR TITLE
Work around AMP's media library modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.3.11
+
+- Bug: AMP plugin compatibility with featured image modal selection
+
 ## v0.3.10
 
 - Enhancement: Add Asset Manager Framework support

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -24,6 +24,7 @@ function setup() {
 
 	// Add scripts for cropper whenever media modal is loaded.
 	add_action( 'wp_enqueue_media', __NAMESPACE__ . '\\enqueue_scripts', 1 );
+	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\unhook_amp_media_library_notice', 11 );
 
 	// Save crop data.
 	add_action( 'wp_ajax_hm_save_crop', __NAMESPACE__ . '\\ajax_save_crop' );
@@ -108,6 +109,21 @@ function enqueue_scripts( $hook = false ) {
 	);
 
 	wp_set_script_translations( 'hm-smart-media-cropper', 'hm-smart-media' );
+}
+
+/**
+ * Unhook Google AMP's media frame modifications.
+ *
+ * AMP adds some notices to the media library that interfere with Smart Media's edit state.
+ *
+ * @return void
+ */
+function unhook_amp_media_library_notice() {
+	wp_add_inline_script(
+		'amp-block-editor',
+		'wp.hooks.removeFilter( \'editor.MediaUpload\', \'ampEditorBlocks/withMediaLibraryNotice\' );',
+		'after'
+	);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-media",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "A smarter media library for WordPress",
   "repository": "https://github.com/humanmade/smart-media",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Advanced media tools that take advantage of Rekognition and Tachyon.
  * Author: Human Made Limited
  * License: GPL-3.0
- * Version: 0.3.10
+ * Version: 0.3.11
  */
 
 namespace HM\Media;


### PR DESCRIPTION
AMP makes some alterations to the media modal at a later stage that breaks Smart Media's edit mode. The change is just that it adds a notice to the media library with the recommended image size but this is repeated in the sidebar.

A future TODO will be to do a deep dive into the root cause and make this properly compatible.

Follow on for #127 - this was already fixed but the AMP plugin breaks it.