### PR TITLE
Add a filter to skip processing specific attachments

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -132,6 +132,11 @@ function rest_api_fields( WP_REST_Response $response ) : WP_REST_Response {
 		return $response;
 	}
 
+	// Check if we should skip this one.
+	if ( skip_attachment( $data['id'] ) ) {
+		return $response;
+	}
+
 	if ( isset( $data['source_url'] ) && $data['media_type'] === 'image' ) {
 		$data['original_url'] = $data['source_url'];
 		$data['source_url'] = tachyon_url( $data['source_url'] );
@@ -305,6 +310,11 @@ function attachment_js( $response, $attachment ) {
 		return $response;
 	}
 
+	// Check if we should skip.
+	if ( skip_attachment( $attachment->ID ) ) {
+		return $response;
+	}
+
 	$meta = wp_get_attachment_metadata( $attachment->ID );
 
 	if ( ! $meta ) {
@@ -389,6 +399,24 @@ function attachment_js( $response, $attachment ) {
 }
 
 /**
+ * Check whether to skip an attachment for Smart Media processing.
+ *
+ * @uses filter hm.smart-media.skip-attachment
+ *
+ * @param integer $attachment_id The attachment ID to check.
+ * @return boolean
+ */
+function skip_attachment( int $attachment_id ) : bool {
+	/**
+	 * Filters whether to skip a given attachment.
+	 *
+	 * @param bool $skip If true then the attachment should be skipped, default false.
+	 * @param int $attachment_id The attachment ID to check.
+	 */
+	return (bool) apply_filters( 'hm.smart-media.skip-attachment', false, $attachment_id );
+}
+
+/**
  * Updates attachments that aren't images but have thumbnails
  * like PDFs to use Tachyon URLs.
  *
@@ -398,6 +426,10 @@ function attachment_js( $response, $attachment ) {
  */
 function attachment_thumbs( $response, $attachment ) : array {
 	if ( ! is_array( $response ) || wp_attachment_is_image( $attachment ) ) {
+		return $response;
+	}
+
+	if ( skip_attachment( $attachment->ID ) ) {
 		return $response;
 	}
 
@@ -696,6 +728,10 @@ function filter_attachment_meta_data( $data, $attachment_id ) {
 
 	// Only modify if valid format and for images.
 	if ( ! is_array( $data ) || ! wp_attachment_is_image( $attachment_id ) ) {
+		return $data;
+	}
+
+	if ( skip_attachment( $attachment_id ) ) {
 		return $data;
 	}
 


### PR DESCRIPTION
This is to allow for integrations with tools like Asset Manager Framework so certain images are not handled by Smart Media.