### PR TITLE
Deselect blocks when selecting featured image

### DIFF
--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -172,6 +172,14 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
       // Update the placeholder the featured image frame uses to set its
       // default selection from.
       if ( isFeaturedImage ) {
+        // Avoid updating attributes on any selected blocks.
+        if ( wp && wp.data ) {
+          const selectedBlock = wp.data.select( 'core/block-editor' )?.getSelectedBlock();
+          if ( selectedBlock ) {
+            wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
+          }
+        }
+
         wp.media.view.settings.post.featuredImageId = single.get( 'id' );
       }
 


### PR DESCRIPTION
A similar issue was fixed back in #80 

There's a bit of a connection between block updates and the modified media upload window that work fine for image blocks and the like, however it's possible to confuse things if an image block is selected and then you click to set or change the featured image.

It causes the inline image block that was selected to update to use the featured image as well.