### PR TITLE
Fix TACHYON_URL matching issues when processing content images

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -39,11 +39,6 @@ function setup() {
 	// Preserve quality when editing original.
 	add_filter( 'jpeg_quality', __NAMESPACE__ . '\\jpeg_quality', 10, 2 );
 
-	// tmp fix for now
-	// add_filter( 'tachyon_url', function ( $url ) {
-	// 	return str_replace( get_main_site_url( '/' ), site_url( '/' ), $url );
-	// }, 40 );
-
 	/**
 	 * Tachyon settings.
 	 */

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -9,7 +9,6 @@ use Tachyon;
 use WP_Post;
 use WP_REST_Response;
 
-use function Altis\Cloud\get_main_site_url;
 use function HM\Media\get_asset_url;
 
 /**

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -902,6 +902,20 @@ function massage_meta_data_for_orientation( array $meta_data ) {
 }
 
 /**
+ * Check if this image matches the tachyon host and path. Allows subdomains.
+ *
+ * @param string $image Image HTML or URL.
+ * @return boolean
+ */
+function is_tachyon_url( string $image ) : bool {
+	if ( ! defined( 'TACHYON_URL' ) ) {
+		return false;
+	}
+
+	return strpos( $image, str_replace( [ 'http://', 'https://' ], '', TACHYON_URL ) ) !== false;
+}
+
+/**
  * Add our special handlers for width & height attrs and srcset attributes.
  *
  * @param string $filtered_image Full img tag with attributes that will replace the source img tag.
@@ -910,7 +924,7 @@ function massage_meta_data_for_orientation( array $meta_data ) {
  * @return string Full img tag with attributes that will replace the source img tag.
  */
 function content_img_tag( string $filtered_image, string $context, int $attachment_id ) : string {
-	if ( ! defined( 'TACHYON_URL' ) || strpos( $filtered_image, TACHYON_URL ) === false ) {
+	if ( ! is_tachyon_url( $filtered_image ) ) {
 		return $filtered_image;
 	}
 
@@ -945,7 +959,7 @@ function content_img_tag( string $filtered_image, string $context, int $attachme
  * @return bool The filtered value, defaults to <code>true</code>.
  */
 function img_tag_add_attr( bool $value, string $image ) : bool {
-	return ! defined( 'TACHYON_URL' ) || strpos( $image, TACHYON_URL ) === false ? $value : false;
+	return ! is_tachyon_url( $image ) ? $value : false;
 }
 
 /**
@@ -1151,7 +1165,7 @@ function image_srcset( array $sources, array $size_array, string $image_src, arr
 	list( $width, $height ) = array_map( 'absint', $size_array );
 
 	// Ensure this is _not_ a tachyon image, not always the case when parsing from post content.
-	if ( ! defined( 'TACHYON_URL' ) || strpos( $image_src, TACHYON_URL ) === false ) {
+	if ( ! is_tachyon_url( $image_src ) ) {
 		// If the aspect ratio requested matches a custom crop size, pull that
 		// crop (in case there's a user custom crop). Otherwise just use the
 		// given dimensions.

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -9,6 +9,7 @@ use Tachyon;
 use WP_Post;
 use WP_REST_Response;
 
+use function Altis\Cloud\get_main_site_url;
 use function HM\Media\get_asset_url;
 
 /**
@@ -38,6 +39,11 @@ function setup() {
 
 	// Preserve quality when editing original.
 	add_filter( 'jpeg_quality', __NAMESPACE__ . '\\jpeg_quality', 10, 2 );
+
+	// tmp fix for now
+	// add_filter( 'tachyon_url', function ( $url ) {
+	// 	return str_replace( get_main_site_url( '/' ), site_url( '/' ), $url );
+	// }, 40 );
 
 	/**
 	 * Tachyon settings.
@@ -912,7 +918,12 @@ function is_tachyon_url( string $image ) : bool {
 		return false;
 	}
 
-	return strpos( $image, TACHYON_URL ) !== false;
+	// TACHYON_URL can be filtered on output so this is the only reliable method to
+	// check an image is handled by Tachyon.
+	$uploads_dir = wp_upload_dir();
+	$tachyon_base_url = dirname( tachyon_url( $uploads_dir['baseurl'] . '/image.jpg' ) );
+
+	return strpos( $image, $tachyon_base_url ) !== false;
 }
 
 /**
@@ -1049,7 +1060,7 @@ function add_width_and_height_attr( $image, $image_meta ) : string {
 	if ( empty( $image_meta ) ) {
 		return $image;
 	}
-	
+
 	$image_src = preg_match( '/src="([^"]+)"/', $image, $match_src ) ? $match_src[1] : '';
 
 	// Return early if we couldn't get the image source.
@@ -1087,7 +1098,7 @@ function add_srcset_and_sizes_attr( $image, $image_meta, $attachment_id ) : stri
 	if ( empty( $image_meta ) ) {
 		return $image;
 	}
-	
+
 	$image_src = preg_match( '/src="([^"]+)"/', $image, $match_src ) ? $match_src[1] : '';
 
 	// Return early if we couldn't get the image source.

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -912,7 +912,7 @@ function is_tachyon_url( string $image ) : bool {
 		return false;
 	}
 
-	return strpos( $image, str_replace( [ 'http://', 'https://' ], '', TACHYON_URL ) ) !== false;
+	return strpos( $image, TACHYON_URL ) !== false;
 }
 
 /**

--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -158,9 +158,16 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
     libraryState.get( 'selection' ).on( 'selection:single', () => {
       const single = this.state( 'edit' ).get( 'selection' ).single();
 
+			if ( this._state === 'edit' ) {
+				return;
+			}
+
       // Check that the attachment is a complete object. Built in placeholders
       // exist for the cover block that can confuse things.
-      if ( ( ! isFeaturedImage && ! single.get( 'url' ) ) || ! single.get( 'id' ) ) {
+      if ( ! single.get( 'id' ) ) {
+				single.fetch().then( () => {
+					this.setState( 'edit' );
+				} );
         return;
       }
 
@@ -180,6 +187,9 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
           }
         }
 
+				// Set size back to full.
+				single.set( { size: 'full' } );
+
         wp.media.view.settings.post.featuredImageId = single.get( 'id' );
       }
 
@@ -192,7 +202,11 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
         wp.media.view.settings.post.featuredImageId = -1;
       }
 
-      this.setState( libraryState.id );
+			if ( this._state !== 'edit' ) {
+				return;
+			}
+
+			this.setState( libraryState.id );
     } );
   },
   onCreateImageEditorContent: function ( region ) {

--- a/inc/cropper/src/cropper.js
+++ b/inc/cropper/src/cropper.js
@@ -33,7 +33,7 @@ addFilter(
 
 // Ensure Smart Media is supported by Asset Manager Framework.
 addAction( 'amf.extend_toolbar', 'smartmedia/cropper', extend_toolbar => {
-	Media.view.Toolbar = extend_toolbar( Media.view.Toolbar, 'apply' );
+  Media.view.Toolbar = extend_toolbar( Media.view.Toolbar, 'apply' );
 } );
 
 
@@ -158,16 +158,16 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
     libraryState.get( 'selection' ).on( 'selection:single', () => {
       const single = this.state( 'edit' ).get( 'selection' ).single();
 
-			if ( this._state === 'edit' ) {
-				return;
-			}
+      if ( this._state === 'edit' ) {
+        return;
+      }
 
       // Check that the attachment is a complete object. Built in placeholders
       // exist for the cover block that can confuse things.
       if ( ! single.get( 'id' ) ) {
-				single.fetch().then( () => {
-					this.setState( 'edit' );
-				} );
+        single.fetch().then( () => {
+          this.setState( 'edit' );
+        } );
         return;
       }
 
@@ -187,8 +187,8 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
           }
         }
 
-				// Set size back to full.
-				single.set( { size: 'full' } );
+        // Set size back to full.
+        single.set( { size: 'full' } );
 
         wp.media.view.settings.post.featuredImageId = single.get( 'id' );
       }
@@ -202,11 +202,11 @@ Media.view.MediaFrame.Select = MediaFrameSelect.extend( {
         wp.media.view.settings.post.featuredImageId = -1;
       }
 
-			if ( this._state !== 'edit' ) {
-				return;
-			}
+      if ( this._state !== 'edit' ) {
+        return;
+      }
 
-			this.setState( libraryState.id );
+      this.setState( libraryState.id );
     } );
   },
   onCreateImageEditorContent: function ( region ) {

--- a/inc/cropper/src/views/image-editor.js
+++ b/inc/cropper/src/views/image-editor.js
@@ -91,8 +91,8 @@ const ImageEditor = Media.View.extend( {
 
 		// Reset to focal point or smart crop by default.
 		if ( ! crop.hasOwnProperty( 'x' ) ) {
+			const [ cropWidth, cropHeight ] = getMaxCrop( width, height, size.width, size.height );
 			if ( focalPoint.hasOwnProperty( 'x' ) ) {
-				const [ cropWidth, cropHeight ] = getMaxCrop( width, height, size.width, size.height );
 				this.setSelection( {
 					x: Math.min( width - cropWidth, Math.max( 0, focalPoint.x - ( cropWidth / 2 ) ) ),
 					y: Math.min( height - cropHeight, Math.max( 0, focalPoint.y - ( cropHeight / 2 ) ) ),
@@ -108,6 +108,16 @@ const ImageEditor = Media.View.extend( {
 					} )
 					.then( ( { topCrop } ) => {
 						this.setSelection( topCrop );
+					} )
+					.catch( error => {
+						console.error( error );
+						// Fallback to centered crop, can fail due to cross-origin canvas tainting.
+						this.setSelection( {
+							x: Math.max( 0 , ( width - cropWidth ) / 2 ),
+							y: Math.max( 0, ( height - cropHeight ) / 2 ),
+							width: cropWidth,
+							height: cropHeight,
+						} );
 					} );
 			}
 		} else {


### PR DESCRIPTION
There is a problem when determining whether to prevent WP from adding its default image tag attributes when the TACHYON_URL constant either does not match the given image URL. This seems to only affect subsites on multisite install, e.g. on a subdomain.

Additionally:
- Initial opening of media modal no longer sets correct image editing view first time
- Images in the smart editor UI from a different host cause a JS error preventing custom crops being set due to "contaminated canvas"