### PR TITLE
223: Fix a warning when filtering attachment metadata

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -765,6 +765,10 @@ function filter_attachment_meta_data( $data, $attachment_id ) {
 		return $data;
 	}
 
+	if ( empty( $data['file'] ) {
+		return $data;
+	}
+
 	if ( skip_attachment( $attachment_id ) ) {
 		return $data;
 	}


### PR DESCRIPTION
Attempt to fix a warning when filtering attachment metadata if `data['file']` is null/empty. This warning happens on every page load.