### PR TITLE
Fix-223 - Parse Error

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -765,7 +765,7 @@ function filter_attachment_meta_data( $data, $attachment_id ) {
 		return $data;
 	}
 
-	if ( empty( $data['file'] ) {
+	if ( empty( $data['file'] ) ) {
 		return $data;
 	}
 


### PR DESCRIPTION
https://github.com/humanmade/smart-media/issues/223

In https://github.com/humanmade/smart-media/pull/225/files we introduced a new bug that would cause the following:

```
PHP Parse error:  syntax error, unexpected token "{"
```