### PR TITLE
Correctly add img optimisations

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -963,61 +963,6 @@ function content_img_tag( string $filtered_image, string $context, int $attachme
 }
 
 /**
- * Maybe add Loading optimization attributes to the img tag.
- *
- * @param array|false $loading_attrs False by default, or array of loading optimization attributes to short-circuit.
- * @param string $tag_name The tag name.
- * @param array $attr Array of the attributes for the tag.
- * @param string $context Context for the element for which the loading optimization attribute is requested.
- *
- * @return string
- */
-function maybe_add_loading_optimization_attributes( $loading_attrs, $tag_name, $attr, $context ) {
-	$allowed_context = [ 'the_content', 'template' ];
-	if ( ! in_array( $context, $allowed_context , true ) ) {
-		return $loading_attrs;
-	}
-
-	// Only apply to img tags.
-	if ( $tag_name !== 'img' ) {
-		return $loading_attrs;
-	}
-
-	// Check if lazy loading is enabled.
-	if ( ! wp_lazy_loading_enabled( $tag_name, $context ) ) {
-		return $loading_attrs;
-	}
-
-	// Count images to determine when we should fetchpriority and loading attribute.
-	static $count_images = 1;
-
-	/**
-	 * Filters the threshold for how many of the first content media elements to not lazy-load.
-	 *
-	 * For these first content media elements, the `loading` attribute will be omitted. By default, this is the case
-	 * for only the very first content media element.
-	 *
-	 * @since 5.9.0
-	 * @since 6.3.0 The default threshold was changed from 1 to 3.
-	 *
-	 * @param int $omit_threshold The number of media elements where the `loading` attribute will not be added. Default 3.
-	 */
-	$omit_threshold = apply_filters( 'wp_omit_loading_attr_threshold', 3 );
-
-	// Only apply fetchpriority to the first image.
-	if ( $count_images === 1 ) {
-		$loading_attrs['fetchpriority'] = 'high';
-	} elseif( $count_images > $omit_threshold ) {
-		$loading_attrs['loading'] = 'lazy';
-	}
-
-	// Increment image count.
-	$count_images++;
-
-	return $loading_attrs;
-}
-
-/**
  * Filters whether to add various attributes to the img tag markup.
  *
  * We override this to ensure compatibility with Tachyon & smart media.

--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -85,9 +85,6 @@ function setup() {
 	 */
 	add_filter( 'wp_content_img_tag', __NAMESPACE__ . '\\content_img_tag', 10, 3 );
 
-	// Ensure loading and fetchpriority attributes are added to images.
-	add_filter( 'wp_get_loading_optimization_attributes', __NAMESPACE__ . '\\maybe_add_loading_optimization_attributes', 10, 4 );
-
 	// Ensure the get dimensions function understands Tachyon.
 	add_filter( 'wp_image_src_get_dimensions', __NAMESPACE__ . '\\src_get_dimensions', 10, 4 );
 
@@ -955,6 +952,12 @@ function content_img_tag( string $filtered_image, string $context, int $attachme
 	if ( ! str_contains( $filtered_image, ' srcset=' ) ) {
 		$filtered_image = add_srcset_and_sizes_attr( $filtered_image, $image_meta, $attachment_id );
 	}
+
+	// Call core function to add loading optimization attributes again.
+	// These rely on width/heights being set correctly which is not set at the point core calls them.
+	// See wp_img_tag_add_auto_sizes
+	$filtered_image = wp_img_tag_add_loading_optimization_attrs( $filtered_image, $context );
+	$filtered_image = wp_img_tag_add_auto_sizes( $filtered_image );
 
 	return $filtered_image;
 }


### PR DESCRIPTION
I've noticed that images are still not correctly getting lazy loading attributes applied - despite some recent efforts to address this: https://github.com/humanmade/smart-media/pull/232

I think this is the wrong fix. 

The main reason is that this doesn't actually seem to be working for images in post content. I think the reason for this is that even if we're filtering `wp_get_loading_optimization_attributes` to set `loading=lazy`, this doesn't get added to an image unless it explicitly has width and height. See https://github.com/WordPress/WordPress/blob/master/wp-includes/media.php#L2161.

This logic is pretty important - if we lazy load an image without width/height, it can introduce layout shift that would end up negating the performance benefits of lazy loading. We should probably leave this up to core as much as we can .

In my opinion a better fix is to re-call the core functions `wp_img_tag_add_loading_optimization_attrs` and `wp_img_tag_add_auto_sizes` after the new ones are added. We can do this in `content_img_tag`. This more closely replicates what core does.

This is a bit of a nightmare unpicking what's going on here so I may well be missing something!

