### PR TITLE
#223 - PHP Warnings when file is missing in filter_attachment_meta_data

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -994,7 +994,7 @@ function img_tag_add_attr( bool $value, string $image ) : bool {
  * @return false|array Returns an array of [width, height] on success, false on failure.
  */
 function get_img_src_dimensions( $image_src, $image_meta ) {
-	if ( empty( $image_meta ) ) {
+	if ( empty( $image_meta ) || empty( $image_meta['file'] ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
See https://github.com/humanmade/smart-media/issues/223

This implements defensive coding. It does not deal with the issue at hand, which is how to deal with SVGs.