### PR TITLE
Fix height and width string calculation to maintain aspect ratio

### DIFF
--- a/inc/cropper/namespace.php
+++ b/inc/cropper/namespace.php
@@ -1083,7 +1083,7 @@ function add_width_and_height_attr( $image, $image_meta ) : string {
 	}
 
 	// Make absolutely sure that height and width attributes are accurate.
-	list( $width, $height ) = wp_constrain_dimensions( $image_meta['width'], $image_meta['height'], $size_array[0], $size_array[1] );
+	list( $width, $height ) = wp_constrain_dimensions( $size_array[0], $size_array[1], $image_meta['width'], $image_meta['height'] );
 
 	$hw = trim( image_hwstring( $width, $height ) );
 	return str_replace( '<img', "<img {$hw}", $image );


### PR DESCRIPTION
The image meta width & height, e.g. max values were not being used correctly for generating the width and height image tag attributes based on what sizes were derived from the query string.

This could result in the aspect ratio being changed, and since the introduction of `sizes="auto"` and aspect ratio settings in WP it could break the way images appear.